### PR TITLE
use depth=1 when git clone

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -85,7 +85,7 @@ func gitClone(w http.ResponseWriter, r *http.Request) {
 
 	url := fmt.Sprintf("git@%s:%s/%s", host, owner, repo)
 	reposPath := filepath.Join(ggcDir, host, owner, repo)
-	cmd := exec.Command("git", "clone", url, reposPath)
+	cmd := exec.Command("git", "clone", "--depth=1", url, reposPath)
 
 	log.Printf("Repository: %s/%s/%s", host, owner, repo)
 


### PR DESCRIPTION
``` sh
% time hub clone rails/rails --depth=1
Cloning into 'rails'...
remote: Counting objects: 3591, done.
remote: Compressing objects: 100% (3047/3047), done.
remote: Total 3591 (delta 155), reused 2121 (delta 33), pack-reused 0
Receiving objects: 100% (3591/3591), 6.28 MiB | 3.99 MiB/s, done.
Resolving deltas: 100% (155/155), done.
Checking connectivity... done.
hub clone rails/rails --depth=1  0.47s user 0.95s system 14% cpu 9.470 total
```

We can clone rails/rails at 10sec if used --depth=1 option.
So I propse this patch. This patch can give us a sense of security when we are using auto clone mode.
